### PR TITLE
#55 Updated image links in markdown files in docs folder to be relative to docs folder instead of absolute to fix image rendering issues

### DIFF
--- a/docs/powerpipe-hcl/card.md
+++ b/docs/powerpipe-hcl/card.md
@@ -13,7 +13,7 @@ Cards can be declared as named resources at the top level of a mod, or they can 
 
 ## Example Usage
 
-<img src="/reference_examples/card_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_1.png" width="200pt" />
 
 <br />
 
@@ -143,7 +143,7 @@ Refer to [JQ Escaping & Interpolation](/docs/powerpipe-hcl/dashboard#jq-escaping
 
 ### Alert Card
 
-<img src="/reference_examples/card_ex_alert.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_alert.png" width="200pt" />
 
 <br />
 
@@ -157,7 +157,7 @@ card {
 
 ### OK Card
 
-<img src="/reference_examples/card_ex_ok.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_ok.png" width="200pt" />
 
 <br />
 
@@ -172,7 +172,7 @@ card {
 
 ### Info Card
 
-<img src="/reference_examples/card_ex_info.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_info.png" width="200pt" />
 
 <br />
 
@@ -188,7 +188,7 @@ card {
 
 ### Dynamic Styling via formal query data structure
 
-<img src="/reference_examples/card_ex_dynamic.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_dynamic.png" width="200pt" />
 
 <br />
 
@@ -215,7 +215,7 @@ card {
 
 ### Static data and static (external) link
 
-<img src="/reference_examples/card_ex_static_link.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_static_link.png" width="200pt" />
 
 <br />
 
@@ -230,7 +230,7 @@ card {
 
 
 ### Dynamic data and static (internal) link
-<img src="/reference_examples/card_ex_internal_link.png" width="200pt" />
+<img src="../../images/reference_examples/card_ex_internal_link.png" width="200pt" />
 
 <br />
 
@@ -259,7 +259,7 @@ card {
 
 
 ### Dynamic link with JQ template
-<img src="/reference_examples/card_ex_dynamic_link.png" width="300pt" />
+<img src="../../images/reference_examples/card_ex_dynamic_link.png" width="300pt" />
 
 <br />
 

--- a/docs/powerpipe-hcl/chart.md
+++ b/docs/powerpipe-hcl/chart.md
@@ -14,7 +14,7 @@ Chart blocks can be declared as named resources at the top level of a mod, or th
 
 ## Example Usage
 
-<img src="/reference_examples/bar_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/bar_chart_ex_1.png" width="100%" />
 
 
 ```hcl
@@ -161,7 +161,7 @@ Alternative values are `none`, which applies no data transforms, or `crosstab` w
 #### Multi-series bar chart with custom properties 
 
 
-<img src="/reference_examples/multi-bar_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/multi-bar_ex_1.png" width="100%" />
 
 ```hcl
 chart {
@@ -238,7 +238,7 @@ chart {
 
 ### Bar Chart
 
-<img src="/reference_examples/bar_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/bar_chart_ex_1.png" width="100%" />
 
 ```hcl
 
@@ -263,7 +263,7 @@ chart {
 ```
 
 ### Column Chart
-<img src="/reference_examples/column_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/column_chart_ex_1.png" width="100%" />
 
 ```hcl
 chart {
@@ -287,7 +287,7 @@ chart {
 
 ### Donut Chart
 
-<img src="/reference_examples/donut_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/donut_chart_ex_1.png" width="100%" />
 
 ```hcl
 chart {
@@ -311,7 +311,7 @@ chart {
 
 
 ### Line Chart
-<img src="/reference_examples/line_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/line_chart_ex_1.png" width="100%" />
 
 ```hcl
 chart {
@@ -334,7 +334,7 @@ chart {
 ```
 
 ### Pie Chart
-<img src="/reference_examples/pie_chart_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/pie_chart_ex_1.png" width="100%" />
 
 ```hcl
 chart {
@@ -358,7 +358,7 @@ chart {
 
 
 ### Stack Chart
-<img src="/reference_examples/column_chart_ex_stack.png" width="100%" />
+<img src="../../images/reference_examples/column_chart_ex_stack.png" width="100%" />
 
 ```hcl
 chart {
@@ -382,7 +382,7 @@ chart {
 
 
 ### Comparison Chart
-<img src="/reference_examples/column_chart_ex_compare.png" width="100%" />
+<img src="../../images/reference_examples/column_chart_ex_compare.png" width="100%" />
 
 ```hcl
 chart {
@@ -406,7 +406,7 @@ chart {
 ```
 
 ### Heatmap Chart
-<img src="/reference_examples/heatmap_chart.png" width="100%" />
+<img src="../../images/reference_examples/heatmap_chart.png" width="100%" />
 
 ```hcl
 chart {

--- a/docs/powerpipe-hcl/container.md
+++ b/docs/powerpipe-hcl/container.md
@@ -12,7 +12,7 @@ Containers can only be declared as anonymous blocks inside a `dashboard` or `con
 
 ## Example Usage
 
-<img src="/reference_examples/container_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/container_ex_1.png" width="100%" />
 
 ```hcl
 

--- a/docs/powerpipe-hcl/dashboard.md
+++ b/docs/powerpipe-hcl/dashboard.md
@@ -16,7 +16,7 @@ For layout, a dashboard consists of 12 grid units, where items inside it will co
 
 ## Example Usage
 
-<img src="/reference_examples/dashboard_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/dashboard_ex_1.png" width="100%" />
 
 ```hcl
 

--- a/docs/powerpipe-hcl/flow.md
+++ b/docs/powerpipe-hcl/flow.md
@@ -13,7 +13,7 @@ Flow blocks can be declared as named resources at the top level of a mod, or the
 
 ## Example Usage
 
-<img src="/reference_examples/flow_sankey_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/flow_sankey_ex_1.png" width="100%" />
 
 
 ```hcl
@@ -191,7 +191,7 @@ For flows that do not conform to a single-parent hierarchical structure, it's' u
 
 ### Sankey with color by category
 
-<img src="/reference_examples/flow_sankey_ex_category.png" width="100%" />
+<img src="../../images/reference_examples/flow_sankey_ex_category.png" width="100%" />
 
 ```hcl
 dashboard "flow_sankey_ex_category" {
@@ -308,7 +308,7 @@ category "aws_vpc_subnet" {
 
 ### sankey with monolithic query
 
-<img src="/reference_examples/flow_sankey_ex_1_mono.png" width="100%" />
+<img src="../../images/reference_examples/flow_sankey_ex_1_mono.png" width="100%" />
 
 ```hcl
 dashboard "flow_sankey_ex_1_mono" {
@@ -366,7 +366,7 @@ dashboard "flow_sankey_ex_1_mono" {
 
 ### Sankey with color by category (monolithic query)
 
-<img src="/reference_examples/flow_sankey_ex_category_mono.png" width="100%" />
+<img src="../../images/reference_examples/flow_sankey_ex_category_mono.png" width="100%" />
 
 ```hcl
   dashboard "flow_sankey_ex_category_mono" {
@@ -436,7 +436,7 @@ dashboard "flow_sankey_ex_1_mono" {
 
 ### Sankey with node/edge data format, color by category, depth
 
-<img src="/reference_examples/flow_sankey_ex_2.png" width="100%" />
+<img src="../../images/reference_examples/flow_sankey_ex_2.png" width="100%" />
 
 ```hcl
 

--- a/docs/powerpipe-hcl/graph.md
+++ b/docs/powerpipe-hcl/graph.md
@@ -11,7 +11,7 @@ Graphs can be declared as a block inside a dashboard or container. The data to b
 
 ## Example Usage
 
-<img src="/reference_examples/graph_ex1.png" width="100%" />
+<img src="../../images/reference_examples/graph_ex1.png" width="100%" />
 
 ```hcl
 dashboard "graph_ex1" {

--- a/docs/powerpipe-hcl/hierarchy.md
+++ b/docs/powerpipe-hcl/hierarchy.md
@@ -12,7 +12,7 @@ Hierarchy blocks can be declared as named resources at the top level of a mod, o
 
 ## Example Usage
 
-<img src="/reference_examples/tree_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/tree_ex_1.png" width="100%" />
 
 ```hcl
 dashboard "tree_ex_nodeonly" {
@@ -169,7 +169,7 @@ Alternatively, you may specify nodes and edges as separate rows.  In this case, 
 ### Tree via monolithic query
 
 
-<img src="/reference_examples/tree_ex_1.png" width="100%" />
+<img src="../../images/reference_examples/tree_ex_1.png" width="100%" />
 
 
 ```hcl
@@ -227,7 +227,7 @@ hierarchy {
 
 ### Tree with color by category [monolithic]
 
-<img src="/reference_examples/tree_ex_color.png" width="100%" />
+<img src="../../images/reference_examples/tree_ex_color.png" width="100%" />
 
 ```hcl
 

--- a/docs/powerpipe-hcl/image.md
+++ b/docs/powerpipe-hcl/image.md
@@ -12,7 +12,7 @@ Image blocks can be declared as named resources at the top level of a mod, or th
 
 ## Example Usage
 
-<img src="/reference_examples/image_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/image_ex_1.png" width="200pt" />
 
 ```hcl
 image {
@@ -63,7 +63,7 @@ Formal data structure:
 
 
 ### Via query
-<img src="/reference_examples/image_ex_torvalds.png" width="200pt" />
+<img src="../../images/reference_examples/image_ex_torvalds.png" width="200pt" />
 
 ```hcl
 image {
@@ -81,7 +81,7 @@ image {
 
 
 ### Dynamic Styling via formal query data structure
-<img src="/reference_examples/image_ex_ken.png" width="200pt" />
+<img src="../../images/reference_examples/image_ex_ken.png" width="200pt" />
 
 ```hcl
 image {

--- a/docs/powerpipe-hcl/input.md
+++ b/docs/powerpipe-hcl/input.md
@@ -13,7 +13,7 @@ Input blocks can be declared as named resources at the top level of a mod, or be
 
 ## Example Usage
 
-<img src="/reference_examples/input_select_open_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/input_select_open_ex_1.png" width="200pt" />
 
 <br />
 
@@ -92,7 +92,7 @@ The data structure for an `input` will depend on the `type`.
 
 ### Single-select with tags
 
-<img src="/reference_examples/input_ex_tags.png" width="400pt" />
+<img src="../../images/reference_examples/input_ex_tags.png" width="400pt" />
 
 <br />
 
@@ -121,7 +121,7 @@ input "instance_arn" {
 
 ### Single-select with fixed options
 
-<img src="/reference_examples/input_ex_static_1.png" width="200pt" />
+<img src="../../images/reference_examples/input_ex_static_1.png" width="200pt" />
 
 
 ```hcl
@@ -137,7 +137,7 @@ input "regions" {
 
 ### Single-select with fixed options, using labels
 
-<img src="/reference_examples/input_ex_static_2.png" width="200pt" />
+<img src="../../images/reference_examples/input_ex_static_2.png" width="200pt" />
 
 
 ```hcl
@@ -157,7 +157,7 @@ input "vpc_id" {
 
 ### Multi-select with dynamic options
 
-<img src="/reference_examples/input_multiselect_open_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/input_multiselect_open_ex_1.png" width="200pt" />
 
 <br />
 
@@ -181,7 +181,7 @@ input "policy_arns" {
 
 ### Select with dynamic options
 
-<img src="/reference_examples/input_select_open_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/input_select_open_ex_1.png" width="200pt" />
 
 <br />
 
@@ -206,7 +206,7 @@ input "vpc_id" {
 
 ### Text input
 
-<img src="/reference_examples/input_text.png" width="200pt" />
+<img src="../../images/reference_examples/input_text.png" width="200pt" />
 
 <br />
 
@@ -224,7 +224,7 @@ input "search_string" {
 
 ### Combo box
 
-<img src="/reference_examples/input_combo.png" width="200pt" />
+<img src="../../images/reference_examples/input_combo.png" width="200pt" />
 
 <br />
 
@@ -248,7 +248,7 @@ input "cost_center" {
 
 ### Multi-select combo box
 
-<img src="/reference_examples/input_multicombo.png" width="200pt" />
+<img src="../../images/reference_examples/input_multicombo.png" width="200pt" />
 
 <br />
 
@@ -272,7 +272,7 @@ input "cost_centers" {
 
 ### Example dashboard using an input
 
-<img src="/reference_examples/inputs_example_dashboard_1.png"  />
+<img src="../../images/reference_examples/inputs_example_dashboard_1.png"  />
 
 <br />
 

--- a/docs/powerpipe-hcl/table.md
+++ b/docs/powerpipe-hcl/table.md
@@ -11,7 +11,7 @@ Table blocks can be declared as named resources at the top level of a mod, or th
 
 
 ## Example Usage
-<img src="/reference_examples/table_ex_1.png"  />
+<img src="../../images/reference_examples/table_ex_1.png"  />
 
 ```hcl
 table {
@@ -113,7 +113,7 @@ Refer to [JQ Escaping & Interpolation](/docs/powerpipe-hcl/dashboard#jq-escaping
 
 
 ### Table with options for columns
-<img src="/reference_examples/table_ex_columns.png" width="400pt"/>
+<img src="../../images/reference_examples/table_ex_columns.png" width="400pt"/>
 
 ```hcl
 table {
@@ -144,7 +144,7 @@ table {
 
 
 ### Table in line mode
-<img src="/reference_examples/table_ex_line.png" width="300pt"/>
+<img src="../../images/reference_examples/table_ex_line.png" width="300pt"/>
 
 ```hcl
 table {
@@ -170,7 +170,7 @@ table {
 
 
 ### Table with links
-<img src="/reference_examples/table_with_links_ex.png" />
+<img src="../../images/reference_examples/table_with_links_ex.png" />
 
 ```hcl
 table {

--- a/docs/powerpipe-hcl/text.md
+++ b/docs/powerpipe-hcl/text.md
@@ -12,7 +12,7 @@ Text blocks can be declared as named resources at the top level of a mod, or the
 
 ## Example Usage
 
-<img src="/reference_examples/text_ex_1.png" width="200pt" />
+<img src="../../images/reference_examples/text_ex_1.png" width="200pt" />
 
 ```hcl
 text {
@@ -41,7 +41,7 @@ text {
 
  ### Plain Text
 
-<img src="/reference_examples/text_raw.png" width="200pt" />
+<img src="../../images/reference_examples/text_raw.png" width="200pt" />
 
 ```hcl
 text {


### PR DESCRIPTION
# Description

Fixes Issue #55 

## What was done?

Markdown files in the docs that references images in the images folder have been modified to use relative paths (../../images/reference_examples/) instead of absolute paths (/reference_examples), so that images are rendered correctly in the documents

## Validation

I validated the documents in the brach to verify that the images are rendered correctly in each markdown document.

Browsers:
Chrome (MacOS) Version 133.0.6943.127
Safari Version 18.3 (20620.2.4.11.5)
Firefox 135.0.1 (aarch64)