### PR TITLE
Fix default value for --listen flag in server documentation

### DIFF
--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -19,7 +19,7 @@ powerpipe server
 |-|-
 |  `--dashboard-timeout int` | Set the dashboard execution timeout, in seconds. The default is `0` (no timeout).
 |  `--database`         |  ***DEPRECATED - See [Setting the Database](/docs/build/mod-database) for the new syntax.***  Sets the [database that Powerpipe will connect to](/docs/run#selecting-a-database). This defaults to the local Steampipe database, but can be any PostgreSQL, MySQL, DuckDB, or SQLite database.
-| `--listen string`   | Accept connections from `local` (localhost only) or `network` (all interfaces / IP addresses) (default `network`).
+| `--listen string`   | Accept connections from `local` (localhost only) or `network` (all interfaces / IP addresses) (default `local`).
 | `--port int`        | Web server port (default `9033`).
 | `--var string=string` | Specify the value of a variable.  Multiple `--var` arguments may be passed. 
 | `--var-file string`| Specify a `.ppvar` file containing variable values.


### PR DESCRIPTION
## Issue
The documentation incorrectly states that the `--listen` flag defaults to `network`, but the actual default is `local` as defined in the code.

Server documentation page, https://powerpipe.io/docs/run/server, was fixed on #69, but the reference was not updated.