### PR TITLE
Add permissions block to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   trigger-vercel-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: {}` to deploy.yml to fix CodeQL warning about unrestricted GITHUB_TOKEN permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)